### PR TITLE
chore(ci): adjust insertion of google fonts (388)

### DIFF
--- a/.github/workflows/foss_check.yml
+++ b/.github/workflows/foss_check.yml
@@ -158,6 +158,13 @@ jobs:
             mv "$artifact/SBOM.spdx" "$original_path/SBOM.spdx"
           done
 
+      # Add Fonts to SBOM
+      - name: Make Script Executable
+        run: chmod +x ./scripts/unix/sbom_entries/add_fonts_to_sbom.sh
+
+      - name: Add Google Fonts to SBOM
+        run: ./scripts/unix/sbom_entries/add_fonts_to_sbom.sh
+
       - name: Set environment variables
         run: echo "GITHUB_ACTOR=${{ github.actor }}" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,6 @@ jobs:
 
       - run: find ./scripts/unix/ -type f -exec chmod +x {} \;
 
-      # Add Fonts to SBOM
-      - name: Make Script Executable
-        run: chmod +x ./scripts/unix/sbom_entries/add_fonts_to_sbom.sh
-
-      - name: Add Google Fonts to SBOM
-        run: ./scripts/unix/sbom_entries/add_fonts_to_sbom.sh
-
-      - name: Commit Changes to SBOM with Semantic Release Style
-        run: |
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config --global user.name "${GITHUB_ACTOR}"
-          git add .
-          git commit -m "chore(sbom): update SBOM with Roboto-Regular font entry" || true
-          git push
-
       # Install Turborepo
       - run: npm i
 

--- a/apps/dev_project/SBOM.spdx
+++ b/apps/dev_project/SBOM.spdx
@@ -24874,6 +24874,11 @@
   ],
   "relationships": [
     {
+      "spdxElementId": "SPDXRef-Package-roboto-regular-0.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
       "relationshipType": "DESCRIBES"

--- a/docs/SBOM.spdx
+++ b/docs/SBOM.spdx
@@ -5803,6 +5803,11 @@
   ],
   "relationships": [
     {
+      "spdxElementId": "SPDXRef-Package-roboto-regular-0.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-Package-docs-1.4.0",
       "relationshipType": "DESCRIBES"

--- a/packages/aws-authenticator/SBOM.spdx
+++ b/packages/aws-authenticator/SBOM.spdx
@@ -24874,6 +24874,11 @@
   ],
   "relationships": [
     {
+      "spdxElementId": "SPDXRef-Package-roboto-regular-0.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
       "relationshipType": "DESCRIBES"

--- a/packages/frontend-framework/SBOM.spdx
+++ b/packages/frontend-framework/SBOM.spdx
@@ -24874,6 +24874,11 @@
   ],
   "relationships": [
     {
+      "spdxElementId": "SPDXRef-Package-roboto-regular-0.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
       "relationshipType": "DESCRIBES"

--- a/packages/shared/SBOM.spdx
+++ b/packages/shared/SBOM.spdx
@@ -24874,6 +24874,11 @@
   ],
   "relationships": [
     {
+      "spdxElementId": "SPDXRef-Package-roboto-regular-0.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-Package-iavofficial.frontend-framework-1.0.0",
       "relationshipType": "DESCRIBES"


### PR DESCRIPTION
Currently, the script for the insertion of Google Fonts into SBOMs is being called in the "Release" pipeline. To ensure a smoother and more straightforward approach, it was moved into the "FOSS Check" pipeline in this PR. This change will help streamline the process and ensure that the SBOMs are correctly updated during the FOSS check phase, where the SBOMs are being generated.